### PR TITLE
animation on hover: also cover replies of replies

### DIFF
--- a/custom-css/mfm-on-hover.css
+++ b/custom-css/mfm-on-hover.css
@@ -1,3 +1,3 @@
-.article:not(:hover) span, .reply-to:not(:hover) span {
+.article:not(:hover) span, .wrpstxzv:not(:hover) span {
 	animation: none !important;
 }


### PR DESCRIPTION
The CSS class is from the `note.sub.vue` misskey client component, so replies as well as replies of replies should be covered with this.
(see https://github.com/misskey-dev/misskey/blob/7e30910ab84e1bec6779b5d4b89db02274768b18/src/client/components/note.sub.vue#L2 )