### PR TITLE
add patch for turning star reacts into likes

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -99,6 +99,10 @@ behaviour might be confusing to some people.
 * **Misskey Version**: since 12.99.0
 * **Description**: Turns Star reactions into ordinary ActivityPub likes.
 
+⚠️ Depending on when you read this, you may also need to patch the issue
+[misskey-dev/misskey#8428](https://github.com/misskey-dev/misskey/pull/8428)
+for this to always behave correctly.
+
 With this patch, all star reactions will be turned into an ordinary like
 activity which will allow you to star a post from Pleroma. Since Mastodon
 only understands likes anyway, its behaviour will not change. Star reacts

--- a/patches/README.md
+++ b/patches/README.md
@@ -14,6 +14,7 @@ Misskey any more.
 3. [Compact Notifications](#Compact-Notifications)
 4. [Compatibility Keyoxide](#compatibility-keyoxide)
 5. [Extend emoji list](#Extend-emoji-list)
+6. [Star is Like](#Star-is-Like)
 
 ## MFM search feature
 
@@ -90,3 +91,15 @@ Adds the "pudding" synonym to the custard emoji, and also newly adds regional
 indicator emojis to the list. These are displayed as letters if alone. Note
 that these become the national flags if put next to each other, so the
 behaviour might be confusing to some people.
+
+## Star is Like
+
+* **Author**: Johann150
+* **Date**: 2022-03-19
+* **Misskey Version**: since 12.99.0
+* **Description**: Turns Star reactions into ordinary ActivityPub likes.
+
+With this patch, all star reactions will be turned into an ordinary like
+activity which will allow you to star a post from Pleroma. Since Mastodon
+only understands likes anyway, its behaviour will not change. Star reacts
+may be displayed as a thumbs up reaction on other Misskey instances.

--- a/patches/star-is-like.patch
+++ b/patches/star-is-like.patch
@@ -1,0 +1,17 @@
+diff --git a/packages/backend/src/remote/activitypub/renderer/like.ts b/packages/backend/src/remote/activitypub/renderer/like.ts
+index 1bf36d470..6f3974291 100644
+--- a/packages/backend/src/remote/activitypub/renderer/like.ts
++++ b/packages/backend/src/remote/activitypub/renderer/like.ts
+@@ -12,8 +12,10 @@ export const renderLike = async (noteReaction: NoteReaction, note: Note) => {
+ 		id: `${config.url}/likes/${noteReaction.id}`,
+ 		actor: `${config.url}/users/${noteReaction.userId}`,
+ 		object: note.uri ? note.uri : `${config.url}/notes/${noteReaction.noteId}`,
+-		content: reaction,
+-		_misskey_reaction: reaction,
++		... (reaction !== '\u2b50' ? {
++			content: reaction,
++			_misskey_reaction: reaction,
++		} : {}),
+ 	} as any;
+ 
+ 	if (reaction.startsWith(':')) {


### PR DESCRIPTION
Multiple people wish to like things from Misskey, but it does not have facilities for it. Instead it was suggested by @solfisher to turn ⭐ reactions to likes.

Also found ActivityPub issues in Misskey & Pleroma while testing this one. 😆